### PR TITLE
update people and results endpoint

### DIFF
--- a/api/core.py
+++ b/api/core.py
@@ -91,7 +91,6 @@ def get_results(**kwargs):
     result_type = kwargs.get('resultType')
     act_id = kwargs.get('actionID')
     sf_id = kwargs.get('samplingFeatureID')
-    site_id = kwargs.get('siteID')
     var_id = kwargs.get('variableID')
     sim_id = kwargs.get('simulationID')
 
@@ -102,7 +101,7 @@ def get_results(**kwargs):
                               simulationid=sim_id,
                               sfid=sf_id,
                               variableid=var_id,
-                              siteid=site_id)
+                              siteid=None)
 
     Results_list = []
     for res in Results:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -24,7 +24,7 @@ produces:
   - application/yaml
   - text/csv
 paths:
-  /affiliations:
+  /affiliations/:
     get:
       tags:
       - affiliations
@@ -33,7 +33,7 @@ paths:
       responses:
         "200":
           description: 200 Response
-  /affiliations/affiliationID/{affiliationID}:
+  /affiliations/affiliationID/{affiliationID}/:
     get:
       tags:
       - affiliations
@@ -103,7 +103,7 @@ paths:
       responses:
         "200":
           description: 200 Response
-  /people:
+  /people/:
     get:
       tags:
       - people
@@ -112,7 +112,57 @@ paths:
       responses:
         "200":
           description: 200 Response
-  /results:
+  /people/peopleID/{peopleID}/:
+    get:
+      tags:
+      - people
+      operationId: getPeopleByPeopleID
+      summary: ODM2 people retrieval by People ID(s)
+      parameters:
+        - name: peopleID
+          in: path
+          description: People ID(s)
+          required: true
+          type: string
+      responses:
+        "200":
+          description: 200 Response
+  /people/firstName/{firstName}/:
+    get:
+      tags:
+      - people
+      operationId: getPeopleByFirstName
+      summary: ODM2 people retrieval by First Name
+      parameters:
+        - name: firstName
+          in: path
+          description: Person First Name
+          required: true
+          type: string
+        - name: lastName
+          in: query
+          description: Person Last Name
+          required: false
+          type: string
+      responses:
+        "200":
+          description: 200 Response
+  /people/lastName/{lastName}/:
+    get:
+      tags:
+      - people
+      operationId: getPeopleByLastName
+      summary: ODM2 people retrieval by Last Name
+      parameters:
+        - name: lastName
+          in: path
+          description: Person Last Name
+          required: true
+          type: string 
+      responses:
+        "200":
+          description: 200 Response
+  /results/:
     get:
       tags:
       - results
@@ -121,6 +171,104 @@ paths:
       produces:
       - application/json
       - application/yaml
+      responses:
+        "200":
+          description: 200 Response
+  /results/resultID/{resultID}/:
+    get:
+      tags:
+      - results
+      operationId: getResultsByResultID
+      summary: ODM2 results retrieval by Result ID(s)
+      parameters:
+        - name: resultID
+          in: path
+          description: Result ID(s)
+          required: true
+          type: string 
+      responses:
+        "200":
+          description: 200 Response
+  /results/resultUUID/{resultUUID}/:
+    get:
+      tags:
+      - results
+      operationId: getResultsByResultUUID
+      summary: ODM2 results retrieval by Result UUID(s)
+      parameters:
+        - name: resultUUID
+          in: path
+          description: Result UUID(s)
+          required: true
+          type: string 
+      responses:
+        "200":
+          description: 200 Response
+  /results/resultType/{resultType}/:
+    get:
+      tags:
+      - results
+      operationId: getResultsByResultType
+      summary: ODM2 results retrieval by Result Type
+      externalDocs: 
+          description: "See all available Result Types"
+          url: "http://vocabulary.odm2.org/resulttype/"
+      parameters:
+        - name: resultType
+          in: path
+          description: Result Type (Name)
+          required: true
+          type: string 
+        - name: actionID
+          in: query
+          description: Action ID
+          required: false
+          type: integer
+        - name: samplingFeatureID
+          in: query
+          description: Sampling Feature ID
+          required: false
+          type: integer
+        - name: variableID
+          in: query
+          description: Variable ID
+          required: false
+          type: integer
+        - name: simulationID
+          in: query
+          description: Simulation ID
+          required: false
+          type: integer
+      responses:
+        "200":
+          description: 200 Response
+  /results/actionID/{actionID}/:
+      get:
+        tags:
+        - results
+        operationId: getResultsByActionID
+        summary: ODM2 results retrieval by Action ID(s)
+        parameters:
+          - name: actionID
+            in: path
+            description: Action ID(s)
+            required: true
+            type: integer
+        responses:
+          "200":
+            description: 200 Response
+  /results/samplingFeatureID/{samplingFeatureID}/:
+    get:
+      tags:
+      - results
+      operationId: getResultsBySamplingfeatureID
+      summary: ODM2 results retrieval by Sampling Feature ID(s)
+      parameters:
+        - name: samplingFeatureID
+          in: path
+          description: Sampling Feature ID(s)
+          required: true
+          type: integer 
       responses:
         "200":
           description: 200 Response

--- a/api/urls.py
+++ b/api/urls.py
@@ -27,9 +27,20 @@ urlpatterns = [
     url(r'^affiliations/organizationCode/(?P<organizationCode>.+)/$',
         AffiliationsViewSet.as_view(), name='affiliations-detail'),
     # People
-    url(r'^people$', PeopleViewSet.as_view(), name='people-list'),
+    url(r'^people/$', PeopleViewSet.as_view(), name='people-list'),
+    url(r'^people/peopleID/(?P<peopleID>.+)/$', PeopleViewSet.as_view(), name='people-detail'),
+    url(r'^people/firstName/(?P<firstName>.+)/$', PeopleViewSet.as_view(), name='people-detail'),
+    url(r'^people/lastName/(?P<lastName>.+)/$', PeopleViewSet.as_view(), name='people-detail'),
     # Results
-    url(r'^results$', ResultsViewSet.as_view(), name='results-list'),
+    url(r'^results/$', ResultsViewSet.as_view(), name='results-list'),
+    url(r'^results/resultID/(?P<resultID>.+)/$', ResultsViewSet.as_view(), name='results-detail'),
+    url(r'^results/resultUUID/(?P<resultUUID>.+)/$', ResultsViewSet.as_view(), name='results-detail'),
+    url(r'^results/resultType/(?P<resultType>.+)/$', ResultsViewSet.as_view(), name='results-detail'),
+    url(r'^results/actionID/(?P<actionID>.+)/$', ResultsViewSet.as_view(), name='results-detail'),
+    url(r'^results/samplingFeatureID/(?P<samplingFeatureID>.+)/$',
+        ResultsViewSet.as_view(), name='results-detail'),
+    url(r'^results/variableID/(?P<variableID>.+)/$', ResultsViewSet.as_view(), name='results-detail'),
+    url(r'^results/simulationID/(?P<simulationID>.+)/$', ResultsViewSet.as_view(), name='results-detail'),
     # url(r'^samplingfeatures$', SamplingFeaturesViewSet.as_view(), name='samplingfeatures-list')
 ]
 

--- a/api/views.py
+++ b/api/views.py
@@ -71,13 +71,18 @@ class PeopleViewSet(APIView):
 
     renderer_classes = (JSONRenderer, YAMLRenderer, CSVRenderer)
 
-    def get(self, request, format=None):
+    def get(self, request, peopleID=None, firstName=None, lastName=None, format=None):
 
         get_kwargs = {
-            'peopleID': request.query_params.get('peopleID'),
-            'firstName': request.query_params.get('firstName'),
-            'lastName': request.query_params.get('lastName')
+            'peopleID': peopleID,
+            'firstName': firstName,
+            'lastName': lastName
         }
+
+        if firstName:
+            get_kwargs.update({
+                'lastName': request.query_params.get('lastName')
+            })
         people = get_people(**get_kwargs)
         serialized = PeopleSerializer(people, many=True)
 
@@ -91,19 +96,29 @@ class ResultsViewSet(APIView):
 
     renderer_classes = (JSONRenderer, YAMLRenderer, CSVRenderer)
 
-    def get(self, request, format=None):
+    def get(self, request, resultID=None,
+            resultUUID=None, resultType=None,
+            actionID=None, samplingFeatureID=None,
+            variableID=None, simulationID=None, format=None):
 
         get_kwargs = {
-            'resultID': request.query_params.get('resultID'),
-            'resultUUID': request.query_params.get('resultUUID'),
-            'resultType': request.query_params.get('resultType'),
-            'actionID': request.query_params.get('actionID'),
-            'samplingFeatureID': request.query_params.get('samplingFeatureID'),
-            'siteID': request.query_params.get('siteID'),
-            'variableID': request.query_params.get('variableID'),
-            'simulationID': request.query_params.get('simulationID')
+            'resultID': resultID,
+            'resultUUID': resultUUID,
+            'resultType': resultType,
+            'actionID': actionID,
+            'samplingFeatureID': samplingFeatureID,
+            'variableID': variableID,
+            'simulationID': simulationID
         }
+        if resultType:
+            get_kwargs.update({
+                'actionID': request.query_params.get('actionID'),
+                'samplingFeatureID': request.query_params.get('samplingFeatureID'),
+                'variableID': request.query_params.get('variableID'),
+                'simulationID': request.query_params.get('simulationID')
+            })
 
+        print(get_kwargs)
         results = get_results(**get_kwargs)
         serialized = ResultSerializer(results, many=True)
 

--- a/odm2rest/static/js/swagger.json
+++ b/odm2rest/static/js/swagger.json
@@ -9,6 +9,178 @@
     }
   },
   "paths": {
+    "/affiliations/affiliationID/{affiliationID}/": {
+      "get": {
+        "tags": [
+          "affiliations"
+        ],
+        "summary": "ODM2 affiliations retrieval by Affiliation ID(s)",
+        "responses": {
+          "200": {
+            "description": "200 Response"
+          }
+        },
+        "parameters": [
+          {
+            "required": true,
+            "type": "string",
+            "description": "Affiliation ID(s)",
+            "in": "path",
+            "name": "affiliationID"
+          }
+        ],
+        "operationId": "getAffiliationsByAffiliationID"
+      }
+    },
+    "/results/resultID/{resultID}/": {
+      "get": {
+        "tags": [
+          "results"
+        ],
+        "summary": "ODM2 results retrieval by Result ID(s)",
+        "responses": {
+          "200": {
+            "description": "200 Response"
+          }
+        },
+        "parameters": [
+          {
+            "required": true,
+            "type": "string",
+            "description": "Result ID(s)",
+            "in": "path",
+            "name": "resultID"
+          }
+        ],
+        "operationId": "getResultsByResultID"
+      }
+    },
+    "/results/": {
+      "get": {
+        "operationId": "getResultsVersion1",
+        "summary": "All ODM2 results retrieval.",
+        "responses": {
+          "200": {
+            "description": "200 Response"
+          }
+        },
+        "tags": [
+          "results"
+        ],
+        "produces": [
+          "application/json",
+          "application/yaml"
+        ]
+      }
+    },
+    "/affiliations/lastName/{lastName}/": {
+      "get": {
+        "tags": [
+          "affiliations"
+        ],
+        "summary": "ODM2 affiliations retrieval by Last Name",
+        "responses": {
+          "200": {
+            "description": "200 Response"
+          }
+        },
+        "parameters": [
+          {
+            "required": true,
+            "type": "string",
+            "description": "Person Last Name",
+            "in": "path",
+            "name": "lastName"
+          }
+        ],
+        "operationId": "getAffiliationsByLastName"
+      }
+    },
+    "/people/firstName/{firstName}/": {
+      "get": {
+        "tags": [
+          "people"
+        ],
+        "summary": "ODM2 people retrieval by First Name",
+        "responses": {
+          "200": {
+            "description": "200 Response"
+          }
+        },
+        "parameters": [
+          {
+            "required": true,
+            "type": "string",
+            "description": "Person First Name",
+            "in": "path",
+            "name": "firstName"
+          },
+          {
+            "required": false,
+            "type": "string",
+            "description": "Person Last Name",
+            "in": "query",
+            "name": "lastName"
+          }
+        ],
+        "operationId": "getPeopleByFirstName"
+      }
+    },
+    "/results/resultType/{resultType}/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 Response"
+          }
+        },
+        "parameters": [
+          {
+            "required": true,
+            "type": "string",
+            "description": "Result Type (Name)",
+            "in": "path",
+            "name": "resultType"
+          },
+          {
+            "required": false,
+            "type": "integer",
+            "description": "Action ID",
+            "in": "query",
+            "name": "actionID"
+          },
+          {
+            "required": false,
+            "type": "integer",
+            "description": "Sampling Feature ID",
+            "in": "query",
+            "name": "samplingFeatureID"
+          },
+          {
+            "required": false,
+            "type": "integer",
+            "description": "Variable ID",
+            "in": "query",
+            "name": "variableID"
+          },
+          {
+            "required": false,
+            "type": "integer",
+            "description": "Simulation ID",
+            "in": "query",
+            "name": "simulationID"
+          }
+        ],
+        "tags": [
+          "results"
+        ],
+        "operationId": "getResultsByResultType",
+        "externalDocs": {
+          "url": "http://vocabulary.odm2.org/resulttype/",
+          "description": "See all available Result Types"
+        },
+        "summary": "ODM2 results retrieval by Result Type"
+      }
+    },
     "/affiliations/organizationCode/{organizationCode}/": {
       "get": {
         "tags": [
@@ -39,35 +211,12 @@
         "operationId": "getAffiliationsByOrganizationCode"
       }
     },
-    "/affiliations/affiliationID/{affiliationID}": {
+    "/people/lastName/{lastName}/": {
       "get": {
         "tags": [
-          "affiliations"
+          "people"
         ],
-        "summary": "ODM2 affiliations retrieval by Affiliation ID(s)",
-        "responses": {
-          "200": {
-            "description": "200 Response"
-          }
-        },
-        "parameters": [
-          {
-            "required": true,
-            "type": "string",
-            "description": "Affiliation ID(s)",
-            "in": "path",
-            "name": "affiliationID"
-          }
-        ],
-        "operationId": "getAffiliationsByAffiliationID"
-      }
-    },
-    "/affiliations/lastName/{lastName}/": {
-      "get": {
-        "tags": [
-          "affiliations"
-        ],
-        "summary": "ODM2 affiliations retrieval by Last Name",
+        "summary": "ODM2 people retrieval by Last Name",
         "responses": {
           "200": {
             "description": "200 Response"
@@ -82,39 +231,7 @@
             "name": "lastName"
           }
         ],
-        "operationId": "getAffiliationsByLastName"
-      }
-    },
-    "/people": {
-      "get": {
-        "summary": "All ODM2 people retrieval.",
-        "responses": {
-          "200": {
-            "description": "200 Response"
-          }
-        },
-        "tags": [
-          "people"
-        ],
-        "operationId": "getPeopleVersion1"
-      }
-    },
-    "/results": {
-      "get": {
-        "operationId": "getResultsVersion1",
-        "summary": "All ODM2 results retrieval.",
-        "responses": {
-          "200": {
-            "description": "200 Response"
-          }
-        },
-        "tags": [
-          "results"
-        ],
-        "produces": [
-          "application/json",
-          "application/yaml"
-        ]
+        "operationId": "getPeopleByLastName"
       }
     },
     "/affiliations/firstName/{firstName}/": {
@@ -147,7 +264,7 @@
         "operationId": "getAffiliationsByFirstName"
       }
     },
-    "/affiliations": {
+    "/affiliations/": {
       "get": {
         "summary": "All ODM2 affiliations retrieval.",
         "responses": {
@@ -159,6 +276,112 @@
           "affiliations"
         ],
         "operationId": "getAffiliationsVersion1"
+      }
+    },
+    "/results/samplingFeatureID/{samplingFeatureID}/": {
+      "get": {
+        "tags": [
+          "results"
+        ],
+        "summary": "ODM2 results retrieval by Sampling Feature ID(s)",
+        "responses": {
+          "200": {
+            "description": "200 Response"
+          }
+        },
+        "parameters": [
+          {
+            "required": true,
+            "type": "integer",
+            "description": "Sampling Feature ID(s)",
+            "in": "path",
+            "name": "samplingFeatureID"
+          }
+        ],
+        "operationId": "getResultsBySamplingfeatureID"
+      }
+    },
+    "/people/": {
+      "get": {
+        "summary": "All ODM2 people retrieval.",
+        "responses": {
+          "200": {
+            "description": "200 Response"
+          }
+        },
+        "tags": [
+          "people"
+        ],
+        "operationId": "getPeopleVersion1"
+      }
+    },
+    "/results/actionID/{actionID}/": {
+      "get": {
+        "tags": [
+          "results"
+        ],
+        "summary": "ODM2 results retrieval by Action ID(s)",
+        "responses": {
+          "200": {
+            "description": "200 Response"
+          }
+        },
+        "parameters": [
+          {
+            "required": true,
+            "type": "integer",
+            "description": "Action ID(s)",
+            "in": "path",
+            "name": "actionID"
+          }
+        ],
+        "operationId": "getResultsByActionID"
+      }
+    },
+    "/people/peopleID/{peopleID}/": {
+      "get": {
+        "tags": [
+          "people"
+        ],
+        "summary": "ODM2 people retrieval by People ID(s)",
+        "responses": {
+          "200": {
+            "description": "200 Response"
+          }
+        },
+        "parameters": [
+          {
+            "required": true,
+            "type": "string",
+            "description": "People ID(s)",
+            "in": "path",
+            "name": "peopleID"
+          }
+        ],
+        "operationId": "getPeopleByPeopleID"
+      }
+    },
+    "/results/resultUUID/{resultUUID}/": {
+      "get": {
+        "tags": [
+          "results"
+        ],
+        "summary": "ODM2 results retrieval by Result UUID(s)",
+        "responses": {
+          "200": {
+            "description": "200 Response"
+          }
+        },
+        "parameters": [
+          {
+            "required": true,
+            "type": "string",
+            "description": "Result UUID(s)",
+            "in": "path",
+            "name": "resultUUID"
+          }
+        ],
+        "operationId": "getResultsByResultUUID"
       }
     }
   },


### PR DESCRIPTION
## Overview

This PR updates `people` and `results` endpoints to follow the conventions @emiliom and I discussed yesterday. It demonstrates the use of both path and query style for REST API.

Note: @emiliom This might be confusing, but regarding the endpoints please pay attention to the yaml changes rather than json, since the json is automatically updated.