### PR TITLE
Fix settings for swagger to get a base domain

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -129,6 +129,7 @@ def swagger_convert():
     """
     with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'swagger', 'swagger.yaml')) as f:
         yaml_data = yaml.load(f)
+        yaml_data['host'] = settings.SWAGGER_SETTINGS['BASE_DOMAIN']
         with open(os.path.join(settings.STATICFILES_DIRS[0], 'js', 'swagger.json'), 'w') as json_file:
             json_file.write(json.dumps(yaml_data, sort_keys=False, indent=2, separators=(',', ': ')))
             # print(json.dumps(yaml_data, sort_keys=False, indent=2, separators=(',', ': ')))

--- a/manage.py
+++ b/manage.py
@@ -4,8 +4,6 @@ import sys
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "odm2rest.settings")
-    from api.utils import swagger_convert
-    swagger_convert()
     try:
         from django.core.management import execute_from_command_line
     except ImportError:

--- a/odm2rest/settings/base.py
+++ b/odm2rest/settings/base.py
@@ -162,7 +162,12 @@ SWAGGER_SETTINGS = {
     'APIS_SORTER': 'alpha',
     'JSON_EDITOR': True,
     'SHOW_REQUEST_HEADERS': True,
-    'SUPPORTED_SUBMIT_METHODS': ['get']
+    'SUPPORTED_SUBMIT_METHODS': ['get'],
+
+    # Application base domain.
+    # If IP Address also include port
+    # else only need domain name
+    'BASE_DOMAIN': '127.0.0.1:8000'
 }
 
 # SQLAlchemy settings

--- a/odm2rest/settings/development.py
+++ b/odm2rest/settings/development.py
@@ -10,6 +10,11 @@ DEBUG = True
 
 ALLOWED_HOSTS = ['127.0.0.1',]
 
+# Application base domain.
+# If IP Address also include port
+# else only need domain name
+SWAGGER_SETTINGS['BASE_DOMAIN'] = '127.0.0.1:8000'
+
 # SQLAlchemy settings
 ODM2DATABASE = {
     'engine': 'db engine',

--- a/odm2rest/urls.py
+++ b/odm2rest/urls.py
@@ -15,10 +15,13 @@ Including another URLconf
 """
 from django.conf.urls import (include, url)
 from django.contrib import admin
+from django.views.generic import RedirectView
 
-
+from api.utils import swagger_convert
+swagger_convert()
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    url(r'^v1/', include('api.urls', namespace='v1'))
+    url(r'^v1/', include('api.urls', namespace='v1')),
+    url(r'^', RedirectView.as_view(url='/v1/docs/', pattern_name='docs', permanent=False))
 ]


### PR DESCRIPTION
## Overview

This PR allows swagger to get a base domain to use in its example queries. User then don't need to go into the `swagger.yaml` to modify it. Will need more settings like this to modify user info for swagger, but it's not top priority right now.

Also, the root url redirects to `/v1/docs` now, rather than an error window. 