### PR TITLE
Fix Results to use query parameters

### DIFF
--- a/api/core.py
+++ b/api/core.py
@@ -119,6 +119,7 @@ def get_results(**kwargs):
     result_type = kwargs.get('resultType')
     act_id = kwargs.get('actionID')
     sf_id = kwargs.get('samplingFeatureID')
+    site_id = kwargs.get('siteID')
     var_id = kwargs.get('variableID')
     sim_id = kwargs.get('simulationID')
 
@@ -129,7 +130,7 @@ def get_results(**kwargs):
                               simulationid=sim_id,
                               sfid=sf_id,
                               variableid=var_id,
-                              siteid=None)
+                              siteid=site_id)
 
     Results_list = []
     for res in Results:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -130,6 +130,7 @@ MethodSerializer = type(
 
 
 # --- FeatureAction Serializer ---
+# TODO: Need to make SamplingFeatureSerializer smarter!
 FeatureAction_dct = get_sertype_dict(odm2_mod.FeatureActions)
 FeatureAction_dct.update({
     'SamplingFeature': SamplingFeatureSerializer(),

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -138,7 +138,8 @@ paths:
           type: string
         - name: resultType
           in: query
-          description: Result Type
+          description: Result Type (Name). <br>
+                       See all available Result Types [here](http://vocabulary.odm2.org/resulttype/).
           required: false
           type: integer
         - name: actionID

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -119,63 +119,28 @@ paths:
       responses:
         "200":
           description: 200 Response
-  /results/:
+  /results:
     get:
       tags:
       - results
       operationId: getResultsVersion1
       summary: All ODM2 results retrieval.
-      produces:
-      - application/json
-      - application/yaml
-      responses:
-        "200":
-          description: 200 Response
-  /results/resultID/{resultID}/:
-    get:
-      tags:
-      - results
-      operationId: getResultsByResultID
-      summary: ODM2 results retrieval by Result ID(s)
       parameters:
         - name: resultID
-          in: path
+          in: query
           description: Result ID(s)
-          required: true
-          type: string 
-      responses:
-        "200":
-          description: 200 Response
-  /results/resultUUID/{resultUUID}/:
-    get:
-      tags:
-      - results
-      operationId: getResultsByResultUUID
-      summary: ODM2 results retrieval by Result UUID(s)
-      parameters:
+          required: false
+          type: string
         - name: resultUUID
-          in: path
+          in: query
           description: Result UUID(s)
-          required: true
-          type: string 
-      responses:
-        "200":
-          description: 200 Response
-  /results/resultType/{resultType}/:
-    get:
-      tags:
-      - results
-      operationId: getResultsByResultType
-      summary: ODM2 results retrieval by Result Type
-      externalDocs: 
-          description: "See all available Result Types"
-          url: "http://vocabulary.odm2.org/resulttype/"
-      parameters:
+          required: false
+          type: string
         - name: resultType
-          in: path
-          description: Result Type (Name)
-          required: true
-          type: string 
+          in: query
+          description: Result Type
+          required: false
+          type: integer
         - name: actionID
           in: query
           description: Action ID
@@ -184,6 +149,11 @@ paths:
         - name: samplingFeatureID
           in: query
           description: Sampling Feature ID
+          required: false
+          type: integer
+        - name: siteID
+          in: query
+          description: Site ID
           required: false
           type: integer
         - name: variableID
@@ -196,36 +166,6 @@ paths:
           description: Simulation ID
           required: false
           type: integer
-      responses:
-        "200":
-          description: 200 Response
-  /results/actionID/{actionID}/:
-      get:
-        tags:
-        - results
-        operationId: getResultsByActionID
-        summary: ODM2 results retrieval by Action ID(s)
-        parameters:
-          - name: actionID
-            in: path
-            description: Action ID(s)
-            required: true
-            type: integer
-        responses:
-          "200":
-            description: 200 Response
-  /results/samplingFeatureID/{samplingFeatureID}/:
-    get:
-      tags:
-      - results
-      operationId: getResultsBySamplingfeatureID
-      summary: ODM2 results retrieval by Sampling Feature ID(s)
-      parameters:
-        - name: samplingFeatureID
-          in: path
-          description: Sampling Feature ID(s)
-          required: true
-          type: integer 
       responses:
         "200":
           description: 200 Response

--- a/api/urls.py
+++ b/api/urls.py
@@ -29,16 +29,7 @@ urlpatterns = [
     url(r'^people/firstName/(?P<firstName>.+)/$', PeopleViewSet.as_view(), name='people-detail'),
     url(r'^people/lastName/(?P<lastName>.+)/$', PeopleViewSet.as_view(), name='people-detail'),
     # Results
-    url(r'^results/$', ResultsViewSet.as_view(), name='results-list'),
-    url(r'^results/resultID/(?P<resultID>.+)/$', ResultsViewSet.as_view(), name='results-detail'),
-    url(r'^results/resultUUID/(?P<resultUUID>.+)/$', ResultsViewSet.as_view(), name='results-detail'),
-    url(r'^results/resultType/(?P<resultType>.+)/$', ResultsViewSet.as_view(), name='results-detail'),
-    url(r'^results/actionID/(?P<actionID>.+)/$', ResultsViewSet.as_view(), name='results-detail'),
-    url(r'^results/samplingFeatureID/(?P<samplingFeatureID>.+)/$',
-        ResultsViewSet.as_view(), name='results-detail'),
-    url(r'^results/variableID/(?P<variableID>.+)/$', ResultsViewSet.as_view(), name='results-detail'),
-    url(r'^results/simulationID/(?P<simulationID>.+)/$',
-        ResultsViewSet.as_view(), name='results-detail'),
+    url(r'^results$', ResultsViewSet.as_view(), name='results-list'),
     # Sampling Features
     url(r'^samplingfeatures/$', SamplingFeaturesViewSet.as_view(), name='samplingfeatures-list'),
     url(r'^samplingfeatures/samplingFeatureID/(?P<samplingFeatureID>.+)/$',

--- a/api/views.py
+++ b/api/views.py
@@ -102,29 +102,19 @@ class ResultsViewSet(APIView):
 
     renderer_classes = (JSONRenderer, YAMLRenderer, CSVRenderer)
 
-    def get(self, request, resultID=None,
-            resultUUID=None, resultType=None,
-            actionID=None, samplingFeatureID=None,
-            variableID=None, simulationID=None, format=None):
+    def get(self, request, format=None):
 
         get_kwargs = {
-            'resultID': resultID,
-            'resultUUID': resultUUID,
-            'resultType': resultType,
-            'actionID': actionID,
-            'samplingFeatureID': samplingFeatureID,
-            'variableID': variableID,
-            'simulationID': simulationID
+            'resultID': request.query_params.get('resultID'),
+            'resultUUID': request.query_params.get('resultUUID'),
+            'resultType': request.query_params.get('resultType'),
+            'actionID': request.query_params.get('actionID'),
+            'samplingFeatureID': request.query_params.get('samplingFeatureID'),
+            'variableID': request.query_params.get('variableID'),
+            'simulationID': request.query_params.get('simulationID'),
+            'siteID': request.query_params.get('siteID')
         }
-        if resultType:
-            get_kwargs.update({
-                'actionID': request.query_params.get('actionID'),
-                'samplingFeatureID': request.query_params.get('samplingFeatureID'),
-                'variableID': request.query_params.get('variableID'),
-                'simulationID': request.query_params.get('simulationID')
-            })
 
-        print(get_kwargs)
         results = get_results(**get_kwargs)
         serialized = ResultSerializer(results, many=True)
 


### PR DESCRIPTION
## Overview

This PR fixes `/results` to use query params instead of path to better match API design.