### PR TITLE
Fix people to use query params

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -60,62 +60,28 @@ paths:
       responses:
         "200":
           description: 200 Response
-  /people/:
+  /people:
     get:
       tags:
       - people
       operationId: getPeopleVersion1
       summary: All ODM2 people retrieval.
-      responses:
-        "200":
-          description: 200 Response
-  /people/peopleID/{peopleID}/:
-    get:
-      tags:
-      - people
-      operationId: getPeopleByPeopleID
-      summary: ODM2 people retrieval by People ID(s)
       parameters:
         - name: peopleID
-          in: path
+          in: query
           description: People ID(s)
-          required: true
+          required: false
           type: string
-      responses:
-        "200":
-          description: 200 Response
-  /people/firstName/{firstName}/:
-    get:
-      tags:
-      - people
-      operationId: getPeopleByFirstName
-      summary: ODM2 people retrieval by First Name
-      parameters:
         - name: firstName
-          in: path
+          in: query
           description: Person First Name
-          required: true
+          required: false
           type: string
         - name: lastName
           in: query
           description: Person Last Name
           required: false
           type: string
-      responses:
-        "200":
-          description: 200 Response
-  /people/lastName/{lastName}/:
-    get:
-      tags:
-      - people
-      operationId: getPeopleByLastName
-      summary: ODM2 people retrieval by Last Name
-      parameters:
-        - name: lastName
-          in: path
-          description: Person Last Name
-          required: true
-          type: string 
       responses:
         "200":
           description: 200 Response

--- a/api/urls.py
+++ b/api/urls.py
@@ -24,10 +24,7 @@ urlpatterns = [
     # Affiliations
     url(r'^affiliations$', AffiliationsViewSet.as_view(), name='affiliations-list'),
     # People
-    url(r'^people/$', PeopleViewSet.as_view(), name='people-list'),
-    url(r'^people/peopleID/(?P<peopleID>.+)/$', PeopleViewSet.as_view(), name='people-detail'),
-    url(r'^people/firstName/(?P<firstName>.+)/$', PeopleViewSet.as_view(), name='people-detail'),
-    url(r'^people/lastName/(?P<lastName>.+)/$', PeopleViewSet.as_view(), name='people-detail'),
+    url(r'^people$', PeopleViewSet.as_view(), name='people-list'),
     # Results
     url(r'^results$', ResultsViewSet.as_view(), name='results-list'),
     # Sampling Features

--- a/api/views.py
+++ b/api/views.py
@@ -77,18 +77,14 @@ class PeopleViewSet(APIView):
 
     renderer_classes = (JSONRenderer, YAMLRenderer, CSVRenderer)
 
-    def get(self, request, peopleID=None, firstName=None, lastName=None, format=None):
+    def get(self, request, format=None):
 
         get_kwargs = {
-            'peopleID': peopleID,
-            'firstName': firstName,
-            'lastName': lastName
+            'peopleID': request.query_params.get('peopleID'),
+            'firstName': request.query_params.get('firstName'),
+            'lastName': request.query_params.get('lastName')
         }
 
-        if firstName:
-            get_kwargs.update({
-                'lastName': request.query_params.get('lastName')
-            })
         people = get_people(**get_kwargs)
         serialized = PeopleSerializer(people, many=True)
 


### PR DESCRIPTION
## Overview

This PR fixes the `/people` endpoint to use query parameters, instead of path.