### PR TITLE
Fix sf urls

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -161,13 +161,29 @@ paths:
         responses:
           "200":
             description: 200 Response
-  /samplingfeatures/:
+  /samplingfeatures:
     get:
       tags:
       - samplingfeatures
       operationId: getSamplingFeatures
       summary: All ODM2 samplingfeatures retrieval.
       parameters:
+        - name: samplingFeatureID
+          in: query
+          description: Sampling Feature ID(s)
+          required: false
+          type: string
+        - name: samplingFeatureCode
+          in: query
+          description: Sampling Feature Code(s)
+          required: false
+          type: string
+        - name: samplingFeatureType
+          in: query
+          description: Sampling Feature Type (Name). <br>
+                       See all available Sampling Feature Types [here](http://vocabulary.odm2.org/samplingfeaturetype/).
+          required: false
+          type: string 
         - name: results
           in: query
           description: Get Sampling Features that has Results
@@ -176,69 +192,6 @@ paths:
       produces:
       - application/json
       - application/yaml
-      responses:
-        "200":
-          description: 200 Response
-  /samplingfeatures/samplingFeatureID/{samplingFeatureID}/:
-    get:
-      tags:
-      - samplingfeatures
-      operationId: getSamplingFeatureBySamplingFeatureID
-      summary: ODM2 samplingfeatures retrieval by Sampling Feature ID(s)
-      parameters:
-        - name: samplingFeatureID
-          in: path
-          description: Sampling Feature ID(s)
-          required: true
-          type: string 
-        - name: results
-          in: query
-          description: Get Sampling Features that has Results
-          required: false
-          type: boolean
-      responses:
-        "200":
-          description: 200 Response
-  /samplingfeatures/samplingFeatureCode/{samplingFeatureCode}/:
-    get:
-      tags:
-      - samplingfeatures
-      operationId: getSamplingFeatureBySamplingFeatureCode
-      summary: ODM2 samplingfeatures retrieval by Sampling Feature Code(s)
-      parameters:
-        - name: samplingFeatureCode
-          in: path
-          description: Sampling Feature Code(s)
-          required: true
-          type: string 
-        - name: results
-          in: query
-          description: Get Sampling Features that has Results
-          required: false
-          type: boolean
-      responses:
-        "200":
-          description: 200 Response
-  /samplingfeatures/samplingFeatureType/{samplingFeatureType}/:
-    get:
-      tags:
-      - samplingfeatures
-      operationId: getSamplingFeatureBySamplingFeatureType
-      summary: ODM2 samplingfeatures retrieval by Sampling Feature Type
-      externalDocs: 
-          description: "See all available Sampling Feature Types"
-          url: "http://vocabulary.odm2.org/samplingfeaturetype/"
-      parameters:
-        - name: samplingFeatureType
-          in: path
-          description: Sampling Feature Type(s)
-          required: true
-          type: string 
-        - name: results
-          in: query
-          description: Get Sampling Features that has Results
-          required: false
-          type: boolean
       responses:
         "200":
           description: 200 Response

--- a/api/urls.py
+++ b/api/urls.py
@@ -28,15 +28,7 @@ urlpatterns = [
     # Results
     url(r'^results$', ResultsViewSet.as_view(), name='results-list'),
     # Sampling Features
-    url(r'^samplingfeatures/$', SamplingFeaturesViewSet.as_view(), name='samplingfeatures-list'),
-    url(r'^samplingfeatures/samplingFeatureID/(?P<samplingFeatureID>.+)/$',
-        SamplingFeaturesViewSet.as_view(), name='samplingfeatures-detail'),
-    url(r'^samplingfeatures/samplingFeatureUUID/(?P<samplingFeatureUUID>.+)/$',
-        SamplingFeaturesViewSet.as_view(), name='samplingfeatures-detail'),
-    url(r'^samplingfeatures/samplingFeatureCode/(?P<samplingFeatureCode>.+)/$',
-        SamplingFeaturesViewSet.as_view(), name='samplingfeatures-detail'),
-    url(r'^samplingfeatures/samplingFeatureType/(?P<samplingFeatureType>.+)/$',
-        SamplingFeaturesViewSet.as_view(), name='samplingfeatures-detail'),
+    url(r'^samplingfeatures$', SamplingFeaturesViewSet.as_view(), name='samplingfeatures-list'),
     # DataSets
     url(r'^datasets/$', DataSetsViewSet.as_view(), name='datasets-list'),
     url(r'^datasets/datasetUUID/(?P<datasetUUID>.+)/$', DataSetsViewSet.as_view(),

--- a/api/views.py
+++ b/api/views.py
@@ -123,15 +123,13 @@ class SamplingFeaturesViewSet(APIView):
 
     renderer_classes = (JSONRenderer, YAMLRenderer, CSVRenderer)
 
-    def get(self, request, samplingFeatureID=None,
-            samplingFeatureCode=None, samplingFeatureUUID=None,
-            samplingFeatureType=None, format=None):
+    def get(self, request, format=None):
 
         get_kwargs = {
-            'samplingFeatureID': samplingFeatureID,
-            'samplingFeatureCode': samplingFeatureCode,
-            'samplingFeatureUUID': samplingFeatureUUID,
-            'samplingFeatureType': samplingFeatureType,
+            'samplingFeatureID': request.query_params.get('samplingFeatureID'),
+            'samplingFeatureCode': request.query_params.get('samplingFeatureCode'),
+            'samplingFeatureUUID': request.query_params.get('samplingFeatureUUID'),
+            'samplingFeatureType': request.query_params.get('samplingFeatureType'),
             'results': False
         }
 


### PR DESCRIPTION
## Overview

This PR fixes `/samplingfeatures` endpoint url so that it uses query parameters.