### PR TITLE
Fix *values serializer to use the original model columns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,11 @@ before_install:
 install:
   - cd $TRAVIS_BUILD_DIR
   - python setup.py sdist && version=$(python setup.py --version) && pushd dist  && pip install odm2rest-${version}.tar.gz && popd
+  - cd $TRAVIS_BUILD_DIR/examples
 
 script:
   - if [[ $TEST_TARGET == 'default' ]]; then
-      python examples/manage.py test odm2rest;
+      python manage.py test odm2rest;
     fi
   - if [[ $TEST_TARGET == 'coding_standards' ]]; then
       flake8 --max-line-length=105 odm2rest;

--- a/odm2rest/core.py
+++ b/odm2rest/core.py
@@ -352,7 +352,7 @@ def get_datasetsvalues(**kwargs):
     dsr_val = []
   
     if isinstance(dataSetsValues, pd.DataFrame):
-        res = READ.getResults(ids=list(dataSetsValues.resultid.values))[0]
+        res = READ.getResults(ids=list(dataSetsValues.ResultID.values))[0]
         res_type = res.ResultTypeCV.lower()
 
         RVSerializer = None

--- a/odm2rest/serializers.py
+++ b/odm2rest/serializers.py
@@ -9,7 +9,7 @@ from rest_framework.serializers import Serializer
 
 import odm2api.ODM2.models as odm2_mod
 
-from utils import (get_col, lower_keys)
+from utils import get_col
 
 
 def get_sertype_dict(odm2_model):
@@ -212,7 +212,7 @@ DataSetsResultsSerializer = type(
 
 # RESULT VALUES SERIALIZERS
 # --- CategoricalResultValues Serializer ---
-CategoricalResultValues_dct = lower_keys(get_sertype_dict(odm2_mod.CategoricalResultValues))
+CategoricalResultValues_dct = get_sertype_dict(odm2_mod.CategoricalResultValues)
 CategoricalResultValuesSerializer = type(
     str('CategoricalResultValuesSerializer'),
     (Serializer,),
@@ -221,7 +221,7 @@ CategoricalResultValuesSerializer = type(
 
 
 # --- MeasurementResultValues Serializer ---
-MeasurementResultValues_dct = lower_keys(get_sertype_dict(odm2_mod.MeasurementResultValues))
+MeasurementResultValues_dct = get_sertype_dict(odm2_mod.MeasurementResultValues)
 MeasurementResultValuesSerializer = type(
     str('MeasurementResultValuesSerializer'),
     (Serializer,),
@@ -230,7 +230,7 @@ MeasurementResultValuesSerializer = type(
 
 
 # --- PointCoverageResultValues Serializer ---
-PointCoverageResultValues_dct = lower_keys(get_sertype_dict(odm2_mod.PointCoverageResultValues))
+PointCoverageResultValues_dct = get_sertype_dict(odm2_mod.PointCoverageResultValues)
 PointCoverageResultValuesSerializer = type(
     str('PointCoverageResultValuesSerializer'),
     (Serializer,),
@@ -239,7 +239,7 @@ PointCoverageResultValuesSerializer = type(
 
 
 # --- ProfileResultValues Serializer ---
-ProfileResultValues_dct = lower_keys(get_sertype_dict(odm2_mod.ProfileResultValues))
+ProfileResultValues_dct = get_sertype_dict(odm2_mod.ProfileResultValues)
 ProfileResultValuesSerializer = type(
     str('ProfileResultValuesSerializer'),
     (Serializer,),
@@ -248,7 +248,7 @@ ProfileResultValuesSerializer = type(
 
 
 # --- SectionResults Serializer ---
-SectionResults_dct = lower_keys(get_sertype_dict(odm2_mod.SectionResults))
+SectionResults_dct = get_sertype_dict(odm2_mod.SectionResults)
 SectionResultsSerializer = type(
     str('SectionResultsSerializer'),
     (Serializer,),
@@ -257,7 +257,7 @@ SectionResultsSerializer = type(
 
 
 # --- SpectraResultValues Serializer ---
-SpectraResultValues_dct = lower_keys(get_sertype_dict(odm2_mod.SpectraResultValues))
+SpectraResultValues_dct = get_sertype_dict(odm2_mod.SpectraResultValues)
 SpectraResultValuesSerializer = type(
     str('SpectraResultValuesSerializer'),
     (Serializer,),
@@ -266,7 +266,7 @@ SpectraResultValuesSerializer = type(
 
 
 # ---TimeSeriesResultValues Serializer ---
-TimeSeriesResultValues_dct = lower_keys(get_sertype_dict(odm2_mod.TimeSeriesResultValues))
+TimeSeriesResultValues_dct = get_sertype_dict(odm2_mod.TimeSeriesResultValues)
 TimeSeriesResultValuesSerializer = type(
     str('TimeSeriesResultValuesSerializer'),
     (Serializer,),
@@ -275,7 +275,7 @@ TimeSeriesResultValuesSerializer = type(
 
 
 # --- TrajectoryResultValues Serializer ---
-TrajectoryResultValues_dct = lower_keys(get_sertype_dict(odm2_mod.TrajectoryResultValues))
+TrajectoryResultValues_dct = get_sertype_dict(odm2_mod.TrajectoryResultValues)
 TrajectoryResultValuesSerializer = type(
     str('TrajectoryResultValuesSerializer'),
     (Serializer,),
@@ -284,7 +284,7 @@ TrajectoryResultValuesSerializer = type(
 
 
 # --- TransectResultValues Serializer ---
-TransectResultValues_dct = lower_keys(get_sertype_dict(odm2_mod.TransectResultValues))
+TransectResultValues_dct = get_sertype_dict(odm2_mod.TransectResultValues)
 TransectResultValuesSerializer = type(
     str('TransectResultValuesSerializer'),
     (Serializer,),


### PR DESCRIPTION
## Overview

This PR fixes the rest api to use the latest changes on ODM2PytonAPI: https://github.com/ODM2/ODM2PythonAPI/pull/136