### PR TITLE
Update *values endpoints and use the conda package for odm2api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,12 +52,6 @@ before_install:
   - conda config --add channels odm2 --force
   - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt
   - source activate TEST
-  # Use development branch of odm2api
-  - git clone https://github.com/ODM2/ODM2PythonAPI.git $HOME/odm2api
-  - cd $HOME/odm2api
-  - git checkout -b development remotes/origin/development
-  - pip install djangorestframework-csv djangorestframework-xml djangorestframework-yaml
-  - pip install -e $HOME/odm2api
   # Coding standards.
   - conda install --channel conda-forge --yes flake8-print flake8-quotes flake8-import-order flake8-builtins flake8-comprehensions flake8-mutable
 

--- a/odm2rest/core.py
+++ b/odm2rest/core.py
@@ -347,7 +347,8 @@ def get_datasetsvalues(**kwargs):
     dataSetsValues = READ.getDataSetsValues(ids=ids,
                                             codes=codes,
                                             uuids=uuids,
-                                            dstype=ds_type)
+                                            dstype=ds_type,
+                                            lowercols=False)
 
     dsr_val = []
   
@@ -438,7 +439,8 @@ def get_resultvalues(**kwargs):
 
     result_values = READ.getResultValues(resultids=ids,
                                          starttime=starttime,
-                                         endtime=endtime)
+                                         endtime=endtime,
+                                         lowercols=False)
 
     res_val = []
     if isinstance(result_values, pd.DataFrame):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pandas
 ipykernel
 jsonschema
 strict-rfc3339
-# djangorestframework-csv
-# djangorestframework-xml
-# djangorestframework-yaml
-# rfc3987
+odm2api==0.7.*
+djangorestframework-csv
+djangorestframework-xml
+djangorestframework-yaml


### PR DESCRIPTION
## Overview

A new release of [ODM2PythonAPI](https://github.com/ODM2/ODM2PythonAPI/releases/tag/v0.7.0) allows the update of the ODM2RESTAPI to use everything in the release. 

This PR updates the *values endpoints discussed in #75. The update uses the CamelCase result to be ready for future releases of ODM2PythonAPI. 

Additionally, #68 has been addressed, so these can be added to requirements, and will be downloaded from conda.

This is definitely a step towards #59 for ODM2RESTAPI.